### PR TITLE
Gitignore Update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ Thumbs.db
 /ios/xcode/native/
 /ios/IOSLauncher.app
 /ios/IOSLauncher.app.dSYM
+
+# Tiled
+.tiled-session


### PR DESCRIPTION
## Description

Gitignores .tiled-session temporary files from Tiled tilemap software.

## Checklist

- [x] You have tested the code locally.
- [x] The code did not runtime during testing.
- [x] You have added documentation where necessary.
